### PR TITLE
Generalized action-based events in remote play spec

### DIFF
--- a/lib/remote/Broker.tsx
+++ b/lib/remote/Broker.tsx
@@ -23,9 +23,11 @@ function makeSecret(): SessionSecret {
 
 export abstract class BrokerBase {
   abstract storeSession(s: Session): Bluebird<any>;
+  abstract addClient(c: ClientID, s: Session): Bluebird<any>;
+
   abstract fetchSessionBySecret(secret: SessionSecret): Bluebird<Session>;
   abstract fetchSessionById(id: SessionID): Bluebird<Session>;
-  abstract addClient(c: ClientID, s: Session): Bluebird<boolean>;
+
   abstract broadcast(e: RemotePlayEvent): void;
 
   createSession(): Bluebird<Session> {

--- a/lib/remote/Events.tsx
+++ b/lib/remote/Events.tsx
@@ -34,14 +34,12 @@ export interface TouchEvent extends EventBase {
   positions: TouchList;
 }
 
-export interface CardEvent extends EventBase {
-  type: 'CARD';
-  card: string; // Serialized card state
-}
-
-export interface NavEvent extends EventBase {
-  type: 'NAV';
-  state: any; // TODO SERIALIZED CARD STATE
+export interface ActionEvent extends EventBase {
+  type: 'ACTION';
+  // Redux action, compressed & serialized to JSON.
+  // It's up to the client implementation to determine
+  // what (if anything) to do with the action.
+  action: string;
 }
 
 export interface ErrorEvent extends EventBase {
@@ -49,12 +47,6 @@ export interface ErrorEvent extends EventBase {
   error: string;
 }
 
-export interface SettingsEvent extends EventBase {
-  type: 'SETTING';
-  key: string;
-  value: string;
-}
+export type RemotePlayEvent = StatusEvent|TouchEvent|ErrorEvent|ActionEvent;
 
-export type RemotePlayEvent = StatusEvent|TouchEvent|CardEvent|NavEvent|ErrorEvent|SettingsEvent;
-
-export type MessageType = 'STATUS'|'TOUCH'|'CARD'|'NAV'|'ERROR'|'SETTING';
+export type MessageType = 'STATUS'|'TOUCH'|'ACTION'|'ERROR';


### PR DESCRIPTION
Make it more "redux action" based, less about specific actions. This allows the app to treat actions as it pleases without changing the network interface.