### PR TITLE
fix weird op behavior by correcting instruction regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.tmp
+Thumbs.db
+npm-debug.log
+package-lock.json

--- a/lib/Regex.tsx
+++ b/lib/Regex.tsx
@@ -12,10 +12,10 @@ export default {
 
   // Breakdown:
   // \*\s*                    Match ">" and any number of spaces (greedy)
-  // (\{\{(.*?)\}\})?         Optionally match "{{some stuff}}"
+  // ({{(.*?)}})?             Optionally match "{{some stuff}}" (lazy)
   // \s*                      Match any number of spaces (greedy)
   // (.*)$                    Match until the end of the string.
-  INSTRUCTION: /^[>]\s*(\{\{(.*)\}\})?\s*(.*)$/,
+  INSTRUCTION: /^[>]\s*({{(.*?)}})?\s*(.*)$/,
 
   // For removing all not-word characters (aka anything except letters and ')
   NOT_WORD: /[^a-zA-Z']/g,
@@ -25,8 +25,8 @@ export default {
 
   // Breakdown:
   // \*\*\s*                  Match "**" and any number of spaces (greedy)
-  // (\{\{(.*?)\}\})?         Optionally match "{{some stuff}}"
+  // ({{(.*?)}})?             Optionally match "{{some stuff}}" (lazy)
   // \s*                      Match any number of spaces (greedy)
   // ((end)|(goto .*))\*\*$   Match only "end" and "goto (any)" until "**" + end of the string.
-  TRIGGER: /^\*\*\s*(\{\{(.*?)\}\})?\s*((end)|(goto .*))\*\*$/,
+  TRIGGER: /^\*\*\s*({{(.*?)}})?\s*((end)|(goto .*))\*\*$/,
 };

--- a/lib/render/QDLParser.test.tsx
+++ b/lib/render/QDLParser.test.tsx
@@ -21,6 +21,18 @@ describe('QDLParser', () => {
     expect(prettifyHTML(qdl.getResult().toString())).toEqual(TestData.basicXML);
   });
 
+  it('parses QDL to XML with lots of conditionals', () => {
+    var qdl = new QDLParser(XMLRenderer);
+
+    qdl.render(new BlockList(TestData.conditionalsMD));
+    var msgs = qdl.getFinalizedLogs();
+
+    expect(msgs['error']).toEqual([]);
+    expect(msgs['warning']).toEqual([]);
+    expect(msgs['internal']).toEqual([]);
+    expect(prettifyHTML(qdl.getResult().toString())).toEqual(TestData.conditionalsXML);
+  });
+
   it('parses QDL to XML with lots of comments', () => {
     var qdl = new QDLParser(XMLRenderer);
 

--- a/lib/render/TestData.tsx
+++ b/lib/render/TestData.tsx
@@ -99,6 +99,34 @@ data.basicXML = `<quest title="Quest Title" data-line="0">
     <trigger data-line="49">end</trigger>
 </quest>`;
 
+data.conditionalsMD = `#Quest Title
+
+_Roleplay Card_
+
+{{a=1}}
+
+{{b="b"}}
+
+> {{a == 1}} Visible {{b}}
+
+> {{a > 1}} Invisible {{b}}
+
+**end**`;
+
+data.conditionalsXML = `<quest title="Quest Title" data-line="0">
+    <roleplay title="Roleplay Card" data-line="2">
+        <p>{{a=1}}</p>
+        <p>{{b=&quot;b&quot;}}</p>
+        <instruction if="a == 1">
+            <p>Visible {{b}}</p>
+        </instruction>
+        <instruction if="a &gt; 1">
+            <p>Invisible {{b}}</p>
+        </instruction>
+    </roleplay>
+    <trigger data-line="12">end</trigger>
+</quest>`;
+
 data.commentsMD = `#Quest Title
 
 _Roleplay Card_


### PR DESCRIPTION
Closes https://github.com/ExpeditionRPG/expedition-app/issues/474

Turns out, was breaking on: `> {{a > 1}} Invisible {{b}}`. Added a test case for this :)

Because the instruction regex was greedily matching the contents / missing the `?`, so it was swallowing anything in between if the instruction had two ops.

Note that this will require re-publishing of quests to fix the issue. The engineered way would be to use that run against all prod quests script you wrote, and see which quests end up with different XML after being run through the latest version of renderer. But, given how much we have on our plate, I'm fine hand-republishing known affected quests, and we can add a TODO for later to double check all quests.