### PR TITLE
Update context error throwing, and comments in InteractionEvent

### DIFF
--- a/lib/parse/Context.test.tsx
+++ b/lib/parse/Context.test.tsx
@@ -6,15 +6,11 @@ const cheerio: any = require('cheerio');
 
 describe('Context', () => {
   describe('evaluateOp', () => {
-    it('calls window.onerr on invalid parse', () => {
-      (window as any).onerror = jasmine.createSpy('onerror');
-      evaluateOp('foo==\'a\'', defaultContext())
-      expect(window.onerror).toHaveBeenCalledTimes(1);
+    it('throws error on invalid parse', () => {
+      expect(() => {evaluateOp('foo==\'a\'', defaultContext());}).toThrow(new Error('Value expected. Note: strings must be enclosed by double quotes (char 6) Op: (foo==\'a\')'));
     });
-    it('calls window.onerr on invalid eval', () => {
-      (window as any).onerror = jasmine.createSpy('onerror');
-      evaluateOp('asdf', defaultContext());
-      expect(window.onerror).toHaveBeenCalledTimes(1);
+    it('throws error on invalid eval', () => {
+      expect(() => {evaluateOp('asdf', defaultContext());}).toThrow(new Error('Undefined symbol asdf Op: (asdf)'));
     });
     it('returns value and updates context', () => {
       const ctx = {...defaultContext(), scope: {b: '1'} as any};

--- a/lib/parse/Context.tsx
+++ b/lib/parse/Context.tsx
@@ -83,7 +83,7 @@ export function evaluateOp(op: string, ctx: Context): any {
     parsed = Math.parse(HtmlDecode(op));
     evalResult = parsed.compile().eval(ctx.scope);
   } catch (err) {
-    return window.onerror(err.message + ' Op: (' + op + ')');
+    throw new Error(err.message + ' Op: (' + op + ')');
   }
 
   // Only return the result IF it doesn't assign a value as its last action.

--- a/lib/remote/Events.tsx
+++ b/lib/remote/Events.tsx
@@ -10,7 +10,7 @@ CARD <serialized card state>
 
 export type ClientID = string;
 
-// Array of [vw, vh] coordinates, e.g. [[1,2], [3,4]].
+// Array of [vw, vh, id] coordinates, e.g. [[1,2,0], [3,4,1]].
 export type TouchList = number[][];
 
 export interface ClientStatus {
@@ -33,7 +33,7 @@ export interface InteractionEvent {
   type: 'INTERACTION';
   id: string; // unique ID for the UI element
   event: string; // "touchstart", etc
-  positions: TouchList; // 0-100 relative positioning from top left of UI element.
+  positions: TouchList; // 0-1000 relative positioning from top left of UI element.
 }
 
 // Action events invoke registered action functions on remote clients when they are broadcast.


### PR DESCRIPTION
The context errors were calling window.onerror, which didn't exist in webworkers (where the exception would be seen by the quest crawler).