### PR TITLE
error on old [icon] syntax

### DIFF
--- a/lib/Regex.tsx
+++ b/lib/Regex.tsx
@@ -7,6 +7,9 @@ export default {
   // (.|\n)*?>                Greedily match any character (incl newline) until closing ">"
   HTML_TAG: /<(\w|(\/\w))(.|\n)*?>/igm,
 
+  // Detects icons in []'s (old syntax)
+  ICON_OLD: /[\[]([a-z_0-9]*)[\]]/ig,
+
   // For selecting ID references, example: (#idName)
   ID: /\(#[a-zA-Z]*\)/g,
 

--- a/lib/render/render/BlockRenderer.test.tsx
+++ b/lib/render/render/BlockRenderer.test.tsx
@@ -366,6 +366,11 @@ describe('BlockRenderer', () => {
 
     it('errors if invalid choice attribute');
 
+    it('errors if old [icon] syntax is used in text');
+
+    it('errors if old [icon] syntax is used in choice');
+
+    it('errors if old [icon] syntax is used in instruction');
   });
 
   describe('toTrigger', () => {

--- a/lib/render/render/BlockRenderer.tsx
+++ b/lib/render/render/BlockRenderer.tsx
@@ -80,6 +80,7 @@ export class BlockRenderer {
         } else {
           // TODO November / once we have support for [art] - remove [icon] errors
           // In roleplaying cards - still invalid in instructions and choices
+          // https://github.com/ExpeditionRPG/expedition-app/issues/403
           if (REGEX.ICON_OLD.test(line)) {
             log.err(
               'use :icon: instead of [icon]',

--- a/lib/render/render/BlockRenderer.tsx
+++ b/lib/render/render/BlockRenderer.tsx
@@ -56,13 +56,39 @@ export class BlockRenderer {
         lineIdx++;
         if (line.indexOf('* ') === 0) {
           let bullet = this.extractBulleted(line, block.startLine + lineIdx, log);
-          choice = (bullet) ? Object.assign({}, bullet, {choice: []}) : null;
-          // TODO: Assert end of lines.
+          if (REGEX.ICON_OLD.test(bullet.text)) {
+            log.err(
+              'use :icon: instead of [icon]',
+              '435',
+              block.startLine + lineIdx + 1
+            );
+          } else {
+            choice = (bullet) ? Object.assign({}, bullet, {choice: []}) : null;
+            // TODO: Assert end of lines.
+          }
         } else if (line.indexOf('> ') === 0) {
           instruction = this.extractInstruction(line);
-          body.push(instruction);
+          if (REGEX.ICON_OLD.test(instruction.text)) {
+            log.err(
+              'use :icon: instead of [icon]',
+              '435',
+              block.startLine + lineIdx + 1
+            );
+          } else {
+            body.push(instruction);
+          }
         } else {
-          body.push(line);
+          // TODO November / once we have support for [art] - remove [icon] errors
+          // In roleplaying cards - still invalid in instructions and choices
+          if (REGEX.ICON_OLD.test(line)) {
+            log.err(
+              'use :icon: instead of [icon]',
+              '435',
+              block.startLine + lineIdx + 1
+            );
+          } else {
+            body.push(line);
+          }
         }
       }
 


### PR DESCRIPTION
After doing this, I'm a bit more convinced that at least some of the error code might make sense to be migrated from QC to QDL just to prevent redundancy... but that poses a lot of architectural challenges (like you said, how to handle QC- and App-specific errors on top of separated QDL errors), so I'm fine punting on that for now