### PR TITLE
Fix tests, remove event ID as a requirement of sendEvent

### DIFF
--- a/lib/remote/Client.test.tsx
+++ b/lib/remote/Client.test.tsx
@@ -26,7 +26,7 @@ export class TestClient extends ClientBase {
 
 describe('Client', () => {
   const basicEventBody: RemotePlayEventBody = {type: 'STATUS'};
-  const basicEvent: RemotePlayEvent = {client: 'testclient', instance: 'testinstance', event: basicEventBody, id: 0};
+  const basicEvent: RemotePlayEvent = {client: 'testclient', instance: 'testinstance', event: basicEventBody, id: null};
 
   it('safely handles malformed messages', (done) => {
     const c = new TestClient();
@@ -43,7 +43,7 @@ describe('Client', () => {
       expect(e.event.type).toEqual('ERROR');
       done();
     });
-    c.doHandleMessage({client: 'testclient', instance: 'testinstance', event: {type: 'UNKNOWN_EVENT_TYPE'}, id: 0} as any as RemotePlayEvent);
+    c.doHandleMessage({client: 'testclient', instance: 'testinstance', event: {type: 'UNKNOWN_EVENT_TYPE'}, id: null} as any as RemotePlayEvent);
   });
 
   it('can subscribe & callback handlers', (done) => {
@@ -58,7 +58,7 @@ describe('Client', () => {
   it('does not try to send if not connected', () => {
     const c = new TestClient();
     c.setConnectState(false);
-    c.sendEvent(0, basicEventBody);
+    c.sendEvent(basicEventBody);
     expect(c.events).toEqual([]);
   });
 
@@ -66,7 +66,7 @@ describe('Client', () => {
     const c = new TestClient();
     c.configure('testclient', 'testinstance');
     c.setConnectState(true);
-    c.sendEvent(0, basicEventBody);
+    c.sendEvent(basicEventBody);
     expect(c.events).toEqual([basicEvent]);
   })
 });

--- a/lib/remote/Client.tsx
+++ b/lib/remote/Client.tsx
@@ -34,11 +34,12 @@ export abstract class ClientBase {
     this.instance = instance;
   }
 
-  sendEvent(eventID: number, event: RemotePlayEventBody): void {
+  sendEvent(event: RemotePlayEventBody): void {
     if (!this.isConnected()) {
       return;
     }
-    this.sendFinalizedEvent({id: eventID, client: this.id, instance: this.instance, event});
+    // ID is set in sendFinalizedEvent
+    this.sendFinalizedEvent({id: null, client: this.id, instance: this.instance, event});
   }
 
   protected handleMessage(e: RemotePlayEvent) {

--- a/lib/remote/Client.tsx
+++ b/lib/remote/Client.tsx
@@ -48,7 +48,7 @@ export abstract class ClientBase {
     }
 
     // Error out if we get an unrecognized message
-    if (['STATUS', 'INTERACTION', 'ACTION', 'ERROR'].indexOf(e.event.type) < 0) {
+    if (['STATUS', 'INTERACTION', 'ACTION', 'ERROR', 'INFLIGHT_COMMIT', 'INFLIGHT_REJECT'].indexOf(e.event.type) < 0) {
       this.publish({id: null, client: null, instance: null, event: {type: 'ERROR', error: 'Received unknown message of type "' + e.event.type + '"'}});
       return;
     }

--- a/lib/remote/Session.test.tsx
+++ b/lib/remote/Session.test.tsx
@@ -1,4 +1,4 @@
-import {Session, SessionSecret, SessionID} from './Broker'
+import {Session, SessionSecret, SessionID} from './Session'
 import * as Bluebird from 'bluebird';
 
 describe('Session', () => {


### PR DESCRIPTION
With this change, we're actually able to do websocket based remote play!